### PR TITLE
Removed api endpoints for creating, updating content_types and permissions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -65,7 +65,7 @@ jobs:
                     pip install -r requirements.txt
             -   name: Run pytests
                 run: |
-                    coverage run -m pytest
+                    coverage run -m pytest -p no:cacheprovider
                     coverage report -m
     
     build:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .pytest_cache/
 .env
 .env.prod
+.coverage

--- a/rapt_service/api.py
+++ b/rapt_service/api.py
@@ -32,17 +32,20 @@ def get_db():
 @app.get("/initialize/")
 async def initialize(db: Session = Depends(get_db)):
     for content in models.Model.metadata.tables.values():
-        if not await crud.filter_objects(db=db,model=models.ContentType,params={"content":content.name}):
-            await crud.create_obj(db=db,model=models.ContentType,schema_model=schemas.ContentTypeCreate(content=content.name))
+        content_types = await crud.filter_objects(db=db,model=models.ContentType,params={"content":content.name})
+        if not content_types:
+            content_type = await crud.create_obj(db=db,model=models.ContentType,schema_model=schemas.ContentTypeCreate(content=content.name))
+        else:
+            content_type = content_types[0]
+        for permission in config.DEFAULT_PERMISSIONS_CLASSES:
+            if not await crud.filter_objects(db=db,model=models.Permission,params={"codename":permission+"_"+content_type.content}):
+                perm_object = {
+                    "name":permission.title()+" "+content_type.content.title(),
+                    "codename":permission+"_"+content_type.content,
+                    "content_type_id":content_type.id
+                }
+                await crud.create_obj(db=db,model=models.Permission,schema_model=schemas.PermissionCreate(**perm_object))    
     return {"message":"System Initialized"}
-
-@app.get("/contenttypes/",response_model=List[schemas.ContentTypeInDBBase])
-async def get_content_types(db: Session = Depends(get_db)) -> List[schemas.ContentTypeInDBBase]:
-    return await crud.get_objects_list(db=db,model=models.ContentType)
-
-@app.post("/permissions/",status_code=201,response_model=schemas.PermissionInDBBase)
-async def create_permission(permission: schemas.PermissionCreate, db: Session = Depends(get_db)) -> schemas.PermissionInDBBase:
-    return await crud.create_obj(db=db,model=models.Permission,schema_model=permission)
 
 #TODO add supoport for filtering/searching for permissions
 @app.get("/permissions/",response_model=List[schemas.PermissionInDBBase])
@@ -52,18 +55,6 @@ async def get_permissions(db: Session = Depends(get_db)) -> List[schemas.Permiss
 @app.get("/permissions/{permission_id}",response_model=schemas.PermissionInDBBase)
 async def get_permission(permission_id: UUID4, db: Session = Depends(get_db)) -> schemas.PermissionInDBBase:
     return await crud.get_obj(db=db,model=models.Permission,id=permission_id)
-
-@app.put("/permissions/{permission_id}",response_model=schemas.PermissionInDBBase)
-async def update_permission(permission_id: UUID4, permission: schemas.PermissionUpdate, db: Session = Depends(get_db)) -> schemas.PermissionInDBBase:
-    return await crud.update_obj(db=db,model=models.Permission,id=permission_id,schema_model=permission)
-
-@app.delete("/permissions/{permission_id}",status_code=204)
-async def delete_permission(permission_id: UUID4, db: Session = Depends(get_db)) -> None:
-    is_deleted = await crud.delete_obj(db=db,model=models.Permission,id=permission_id)
-    if is_deleted:
-        return None
-    else:
-        return {"message":"Something went wrong"},500
     
 @app.post("/roles/",status_code=201,response_model=schemas.RoleInDBBase)
 async def create_role(role: schemas.RoleCreate, db: Session = Depends(get_db)) -> schemas.RoleInDBBase:

--- a/rapt_service/config.py
+++ b/rapt_service/config.py
@@ -20,3 +20,4 @@ class AppSettings(BaseSettings):
 settings = AppSettings()
 DATABASE_URL = f"{settings.mysql_driver}://{settings.mysql_user}:{settings.mysql_password}@{settings.mysql_host}:{settings.mysql_port}/{settings.mysql_database}"
 
+DEFAULT_PERMISSIONS_CLASSES = ["create","read","update","delete"]

--- a/rapt_service/crud.py
+++ b/rapt_service/crud.py
@@ -4,7 +4,7 @@ from pydantic import UUID4, BaseModel
 import models
 import schemas
 from config import logger
-from typing import List
+from typing import List, Sequence
 
 
 #create
@@ -21,11 +21,11 @@ async def get_obj(db: Session, model: models.Model, id: UUID4, ) -> models.Model
     logger.info(f"Getting {model.__tablename__} with id: {id}")
     return db.execute(select(model).where(model.id == id)).scalar_one()
 
-async def get_objects_list(db: Session, model: models.Model) -> List[models.Model]:
+async def get_objects_list(db: Session, model: models.Model) -> Sequence[models.Model]:
     logger.info(f"Getting all {model.__tablename__}")
     return db.scalars(select(model)).all()
 
-async def filter_objects(db: Session, model: models.Model, params: dict) -> List[models.Model]:
+async def filter_objects(db: Session, model: models.Model, params: dict) -> Sequence[models.Model]:
     query = select(model)
     for key, value in params.items():
         query = query.where(getattr(model, key) == value)

--- a/rapt_service/schemas.py
+++ b/rapt_service/schemas.py
@@ -20,27 +20,14 @@ class ModelInDBBase(ModelBase):
 class ContentTypeCreate(BaseModel):
     content: str
 
-class ContentTypeFilter(ContentTypeCreate):
-    pass
-
-class ContentTypeUpdate(ContentTypeCreate):
-    pass
-
 class ContentTypeInDBBase(ModelInDBBase):
     content: str
-
-
 
 # permission schema
 class PermissionCreate(BaseModel):
     name: str
     codename: str
     content_type_id: UUID4
-
-class PermissionUpdate(BaseModel):
-    name: Optional[str] = None
-    codename: Optional[str] = None
-    content_type_id: Optional[UUID4] = None
 
 class PermissionInDBBase(ModelInDBBase):
     name: str

--- a/rapt_service/test_service.py
+++ b/rapt_service/test_service.py
@@ -23,7 +23,6 @@ class Settings(BaseSettings):
 
 settings = Settings()
 TEST_DATABASE_URL = f"{settings.mysql_driver}://{settings.test_database_user}:{settings.test_database_password}@{settings.test_database_host}:{settings.test_database_port}"
-print(TEST_DATABASE_URL)
 
 @pytest.fixture(scope="session")
 def db():
@@ -73,10 +72,6 @@ def test_content_type_permissions_roles_schema(db):
     #test create contenttype object
     content_type = schemas.ContentTypeCreate(**{"content": "users"})
     assert content_type.content == "users"
-    
-    #test update contenttype object
-    content_type_update = schemas.ContentTypeUpdate(**{"content": "users1"})
-    assert content_type_update.content == "users1"
 
     #test get contenttype object
     content_type_get = db.query(models.ContentType).first()
@@ -88,11 +83,6 @@ def test_content_type_permissions_roles_schema(db):
     permission = schemas.PermissionCreate(**{"name": "Can View Users","codename": "view_users","content_type_id": content_type.id})
     assert permission.name == "Can View Users"
     assert permission.codename == "view_users"
-    
-    #test update permission object
-    permission_update = schemas.PermissionUpdate(**{"name": "Can View Users1","codename": "view_users1","content_type_id": content_type.id})
-    assert permission_update.name == "Can View Users1"
-    assert permission_update.codename == "view_users1"
 
     #test get permission object
     permission_get = db.query(models.Permission).first()
@@ -131,49 +121,11 @@ def test_content_type_permissions_roles_schema(db):
 
 #test contenttype crud operations
 @pytest.mark.asyncio
-async def test_content_type_permissions_roles_crud(db):
-    #create contenttype
-    content_type_params = schemas.ContentTypeCreate(**{"content": "users1"})
-    content_type_db =  await crud.create_obj(db,models.ContentType,content_type_params)
-    assert content_type_db in db
-    #read contenttype
-    content_type_get =  await crud.get_obj(db=db, model=models.ContentType,  id=content_type_db.id)
-    assert content_type_get == content_type_db
-    with pytest.raises(sqlalchemy.exc.NoResultFound) as e:
-        await crud.get_obj(db=db, model=models.ContentType,  id=uuid.uuid4())
-    content_types = await crud.get_objects_list(db=db,model=models.ContentType)
-    assert content_type_db in content_types
-    #update contenttype
-    content_type_update = schemas.ContentTypeUpdate(**{"content": "users2"})
-    content_type_db = await crud.update_obj(db=db,model=models.ContentType,id=content_type_db.id,schema_model=content_type_update)
-    assert content_type_db.content == "users2"
-    #delete contenttype
-    is_deleted = await crud.delete_obj(db=db,model=models.ContentType, id=content_type_db.id)
-    assert content_type_db not in db
-    
-    #create permission
-    content_type_params1 = schemas.ContentTypeCreate(**{"content": "users2"})
-    content_type_db1 =  await crud.create_obj(db,models.ContentType,content_type_params1)
-    permission_params = schemas.PermissionCreate(**{"name": "Can View Users2","codename": "view_users2","content_type_id": content_type_db1.id})
-    permission_db =  await crud.create_obj(db,models.Permission,permission_params)
-    assert permission_db in db
-    #read permission
-    permission_get =  await crud.get_obj(db=db, model=models.Permission,  id=permission_db.id)
-    assert permission_get == permission_db
-    with pytest.raises(sqlalchemy.exc.NoResultFound) as e:
-        await crud.get_obj(db=db, model=models.Permission,  id=uuid.uuid4())
-    permissions = await crud.get_objects_list(db=db,model=models.Permission)
-    assert permission_db in permissions
-    #update permission
-    permission_update = schemas.PermissionUpdate(**{"name": "Can View Users3","codename": "view_users3","content_type_id": content_type_db1.id})
-    permission_db = await crud.update_obj(db=db,model=models.Permission,id=permission_db.id,schema_model=permission_update)
-    assert permission_db.name == "Can View Users3"
-    #delete permission
-    is_deleted = await crud.delete_obj(db=db,model=models.Permission, id=permission_db.id)
-    assert permission_db not in db
-    
+async def test_content_type_permissions_roles_crud(db):  
+    content_types =  await crud.get_objects_list(db,models.ContentType)
+    content_type_db = content_types[0]
     #create role
-    permission_params = schemas.PermissionCreate(**{"name": "Can View Users4","codename": "view_users4","content_type_id": content_type_db1.id})
+    permission_params = schemas.PermissionCreate(**{"name": "Can View Users4","codename": "view_users4","content_type_id": content_type_db.id})
     permission_db =  await crud.create_obj(db,models.Permission,permission_params)
     role_params = schemas.RoleCreate(**{"name": "Admin","description": "Admin Role"})
     role_db =  await crud.create_obj(db,models.Role,role_params)
@@ -220,45 +172,15 @@ async def test_initialize_api(client,db):
 #test CRUD api calls for permissions, roles
 @pytest.mark.asyncio
 async def test_permissions_roles_api(client,db):
-    #get content type
-    response = client.get("/contenttypes/")
-    assert response.status_code == 200
-    assert len(response.json()) > 0
-    content_type_id = response.json()[0]["id"]
-    #create permission
-    permission_data = {
-        "name": "Can View Roles",
-        "codename": "view_roles",
-        "content_type_id": str(content_type_id)
-    }
-    response = client.post("/permissions/",json=permission_data)
-    assert response.status_code == 201
-    assert response.json()["name"] == "Can View Roles"
-    permission_id = uuid.UUID(response.json()["id"]) 
-    permission = db.execute(select(models.Permission).where(models.Permission.id == permission_id)).scalar_one()
-    assert permission in db
     #get permissions
     response = client.get("/permissions/")
     assert response.status_code == 200
     assert len(response.json()) >= 1
+    permission_id = uuid.UUID(response.json()[0]["id"])
     #get single permission
     response = client.get(f"/permissions/{permission_id}")
     assert response.status_code == 200
-    assert response.json()["name"] == "Can View Roles"
-    #update permission
-    permission_data = {
-        "name": "Can View Roles1",
-        "codename": "view_roles1",
-        "content_type_id": str(content_type_id)
-    }
-    response = client.put(f"/permissions/{permission_id}",json=permission_data)
-    assert response.status_code == 200
-    assert response.json()["name"] == "Can View Roles1"
-    #delete permission
-    response = client.delete(f"/permissions/{permission_id}")
-    assert response.status_code == 204
-    permission = db.execute(select(models.Permission).where(models.Permission.id == permission_id)).scalar_one_or_none()
-    assert permission is None
+    assert response.json()["name"] != None
     
     #create role
     permissions = db.execute(select(models.Permission)).scalars().all()


### PR DESCRIPTION
1. Removed api endpoints for creating permissions
2. Removed api endpoints for updating permissions
3. Removed api endpoints for creating content_types
4. Removed api endpoints for updating content_types
5. Removed create and update schemas and test suite for these schemas and endpoints
6. Add support for autogenerated permissions


Closes #6